### PR TITLE
#2 Remove placeholder values for email and password. These should really...

### DIFF
--- a/PardotConnector.class.php
+++ b/PardotConnector.class.php
@@ -14,9 +14,9 @@ class PardotConnector
 	private $apiKey		= null;
 	private $outputMode	= 'full'; // choose between 'simple','full','mobile'
 
-	private $email = '####';
-	private $password = '####';
-	private $userKey = '####';
+	private $email = '';
+	private $password = '';
+	private $userKey = '';
 
 
 	/**


### PR DESCRIPTION
... only be set by the authenticate method.(Storage is debateable but could be useful for renewing a connection (catch api key expired))
